### PR TITLE
Ticket_26

### DIFF
--- a/SystemValidator.ps1
+++ b/SystemValidator.ps1
@@ -673,7 +673,7 @@ function Create-HTMLBody {
             $dscStatus = $null
             $lcmConfigs = Get-DscLocalConfigurationManager
             if($lcmConfigs.RefreshMode -ne "Disabled"){
-                while($lcmConfigs.LCMStateDetail -ne ""){
+                while($lcmConfigs.LCMState -ne "Idle"){
                     Start-Sleep -Seconds 5
                     Write-Host "LCM is in status '$($lcmConfigs.LCMStateDetail)', waiting..."
                     $lcmConfigs = Get-DscLocalConfigurationManager


### PR DESCRIPTION
https://github.com/fbprogmbh/SystemValidator/issues/26 

Improved checks on LCMState, now checking for "Idle" state directly, instead of details.

Sleep-Timer is already reduced to five seconds in approve, yet not merged to main.