### PR TITLE
Added check for the IPv6 filter and checking if IPv6 is enabled or not #19

### DIFF
--- a/SystemValidator.ps1
+++ b/SystemValidator.ps1
@@ -827,6 +827,14 @@ function Create-HTMLBody {
                 }
             }
             htmlElement 'tbody' @{} {
+                $object = Get-WSManInstance -ResourceURI winrm/config/Listener -Enumerate
+                $IPv6 = $($object).ListeningOn | Where-Object { $_ -ne '::1' -and $_ -like '*:*' }
+                if ($IPv6) {
+                    ConfigurationCheck "IPv6 Filter" $object.Address "eq" "*"
+                }
+                else {
+                    ConfigurationCheck "IPv6 Filter" $object.Address "info" "IPv6 is disabled"
+                }
                 $hostname = $(hostname)
                 $testWSMan = Test-WSMan -computername $hostname -ErrorVariable "wmitest" -Authentication Negotiate
                 # Run the WinRM command for ipv4/ipv6 filter


### PR DESCRIPTION
If IPv6 is disabled, the IPv6 Filter for the WinRM Listener can be empty.
If Ipv6 is enabled on the system, the IPv6 Filter for the WinRM Listener must be configured with *