### PR TITLE
IPv6Filter configuration check for WinRM

### DIFF
--- a/SystemValidator.ps1
+++ b/SystemValidator.ps1
@@ -827,13 +827,23 @@ function Create-HTMLBody {
                 }
             }
             htmlElement 'tbody' @{} {
-                $object = Get-WSManInstance -ResourceURI winrm/config/Listener -Enumerate
-                $IPv6 = $($object).ListeningOn | Where-Object { $_ -ne '::1' -and $_ -like '*:*' }
-                if ($IPv6) {
-                    ConfigurationCheck "IPv6 Filter" $object.Address "eq" "*"
+                $filterLine = winrm get winrm/config/service | Where-Object { $_ -match "IPv6Filter" }
+                $v6Filter = $filterLine -replace ".*IPv6Filter\s*=\s*", ""
+                if ($v6Filter -match "IPv6Filter") {
+                    $v6Filter = ""
+                }
+                $IPv6reg = Get-ItemPropertyValue -Path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters" -Name DisabledComponents -ErrorAction SilentlyContinue
+                if ($IPv6reg -ne 255 -or $null -eq $IPv6reg) {
+                    $IPv6 = $true
                 }
                 else {
-                    ConfigurationCheck "IPv6 Filter" $object.Address "info" "IPv6 is disabled"
+                    $IPv6 = $false
+                }
+                if ($IPv6) {
+                    ConfigurationCheck "IPv6 Filter" $v6Filter "eq" "*"
+                }
+                else {
+                    ConfigurationCheck "IPv6 Filter" $v6Filter "info" "IPv6 is disabled"
                 }
                 $hostname = $(hostname)
                 $testWSMan = Test-WSMan -computername $hostname -ErrorVariable "wmitest" -Authentication Negotiate

--- a/SystemValidator.ps1
+++ b/SystemValidator.ps1
@@ -827,6 +827,14 @@ function Create-HTMLBody {
                 }
             }
             htmlElement 'tbody' @{} {
+                $object = Get-WSManInstance -ResourceURI winrm/config/Listener -Enumerate
+                $IPv6 = $($object).ListeningOn | Where-Object { $_ -ne '::1' -and $_ -like '*:*' }
+                if ($IPv6) {
+                    ConfigurationCheck "IPv6 Filter" $object.Address "eq" "*"
+                }
+                else {
+                    ConfigurationCheck "IPv6 Filter" $object.Address "info" "IPv6 is disabled"
+                }
                 $hostname = $(hostname)
                 $testWSMan = Test-WSMan -computername $hostname -ErrorVariable "wmitest" -Authentication Negotiate
                 # Run the WinRM command for ipv4/ipv6 filter


### PR DESCRIPTION
Added check for winrm/config/service IPv6Filter
Added check for registry key HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters:DisabledComponents

IPv6Filter can be empty if IPv6 is disabled via registry (value 255)
IPv6Filter must be set to "*" to be compliant if IPv6 is not disabled via registry